### PR TITLE
TOP画面APIカスタマイズ #2

### DIFF
--- a/src/app/Article.php
+++ b/src/app/Article.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Article extends Model
+{
+    //
+}

--- a/src/app/Article.php
+++ b/src/app/Article.php
@@ -3,8 +3,35 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use cebe\markdown\GithubMarkdown as Markdown;
 
 class Article extends Model
 {
-    //
+    /**
+     * 一覧表示用に内容を100文字で丸め、Markdownにparseする
+     */
+    public function getShortMarkBodyAttribute()
+    {
+        // "..."も含めて100文字で丸める
+        $short_body = mb_strimwidth($this->body, 0, 100, '...', 'UTF-8');
+        return $this->parse($short_body);
+    }
+
+    /**
+     * 内容をMarkdownにparseする
+     */
+    public function getMarkBodyAttribute()
+    {
+        return $this->parse($this->body);
+    }
+
+    /**
+     * Markdownにparseする
+     * @param $body
+     */
+    public function parse($body)
+    {
+        $parser = new Markdown();
+        return $parser->parse($body);
+    }
 }

--- a/src/app/Article.php
+++ b/src/app/Article.php
@@ -3,6 +3,7 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use App\ArticleImage;
 use cebe\markdown\GithubMarkdown as Markdown;
 
 class Article extends Model
@@ -33,5 +34,13 @@ class Article extends Model
     {
         $parser = new Markdown();
         return $parser->parse($body);
+    }
+
+    /**
+     * articleImage hasmany設定
+     */
+    public function article_images()
+    {
+        return $this->hasMany(ArticleImage::class);
     }
 }

--- a/src/app/ArticleImage.php
+++ b/src/app/ArticleImage.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use App\Article;
+
+class ArticleImage extends Model
+{
+    /**
+     * article belongsTo設定
+     */
+    public function article()
+    {
+        return $this->belongsTo(Article::class);
+    }
+}

--- a/src/app/Http/Controllers/Api/ArticlesController.php
+++ b/src/app/Http/Controllers/Api/ArticlesController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use Illuminate\Http\Request;
+use App\Article;
+use Illuminate\Support\Facades\Log;
+use cebe\markdown\Markdown as Markdown;
+use App\Http\Controllers\Controller;
+
+class ArticlesController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        $articles = Article::get(['title', 'body'])->toJson();
+        return $articles;
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/src/app/Http/Controllers/Api/ArticlesController.php
+++ b/src/app/Http/Controllers/Api/ArticlesController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Api;
 use Illuminate\Http\Request;
 use App\Article;
 use Illuminate\Support\Facades\Log;
-use cebe\markdown\Markdown as Markdown;
 use App\Http\Controllers\Controller;
 
 class ArticlesController extends Controller
@@ -17,8 +16,13 @@ class ArticlesController extends Controller
      */
     public function index()
     {
-        $articles = Article::get(['title', 'body'])->toJson();
-        return $articles;
+        $articles = Article::get(['title', 'body']);
+        $data = [];
+        foreach ($articles as $idx => $article) {
+            $data[$idx]['title'] = $article->title;
+            $data[$idx]['body'] = $article->short_mark_body;
+        }
+        return $data;
     }
 
     /**

--- a/src/app/Http/Controllers/Api/ArticlesController.php
+++ b/src/app/Http/Controllers/Api/ArticlesController.php
@@ -16,11 +16,15 @@ class ArticlesController extends Controller
      */
     public function index()
     {
-        $articles = Article::get(['title', 'body']);
+        $articles = Article::all();
         $data = [];
         foreach ($articles as $idx => $article) {
             $data[$idx]['title'] = $article->title;
             $data[$idx]['body'] = $article->short_mark_body;
+            // 一覧画面には必要ない情報かも？
+            foreach ($article->article_images as $image) {
+                $data[$idx]['image'][] = $image->image_path;
+            }
         }
         return $data;
     }

--- a/src/composer.json
+++ b/src/composer.json
@@ -9,6 +9,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.1.3",
+        "cebe/markdown": "^1.2",
         "fideloper/proxy": "^4.0",
         "laravel/framework": "5.8.*",
         "laravel/tinker": "^1.0"

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,8 +4,68 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "94d4bf9ac7f4a933030e46a346ee2917",
+    "content-hash": "52c3b29538a81ca15b774bc13343118f",
     "packages": [
+        {
+            "name": "cebe/markdown",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cebe/markdown.git",
+                "reference": "9bac5e971dd391e2802dca5400bbeacbaea9eb86"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cebe/markdown/zipball/9bac5e971dd391e2802dca5400bbeacbaea9eb86",
+                "reference": "9bac5e971dd391e2802dca5400bbeacbaea9eb86",
+                "shasum": ""
+            },
+            "require": {
+                "lib-pcre": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "cebe/indent": "*",
+                "facebook/xhprof": "*@dev",
+                "phpunit/phpunit": "4.1.*"
+            },
+            "bin": [
+                "bin/markdown"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "cebe\\markdown\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Carsten Brandt",
+                    "email": "mail@cebe.cc",
+                    "homepage": "http://cebe.cc/",
+                    "role": "Creator"
+                }
+            ],
+            "description": "A super fast, highly extensible markdown parser for PHP",
+            "homepage": "https://github.com/cebe/markdown#readme",
+            "keywords": [
+                "extensible",
+                "fast",
+                "gfm",
+                "markdown",
+                "markdown-extra"
+            ],
+            "time": "2018-03-26T11:24:36+00:00"
+        },
         {
             "name": "dnoegel/php-xdg-base-dir",
             "version": "0.1",

--- a/src/database/migrations/2019_06_01_064347_create_articles_table.php
+++ b/src/database/migrations/2019_06_01_064347_create_articles_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateArticlesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('articles', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('title');
+            $table->text('body');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('articles');
+    }
+}

--- a/src/database/migrations/2019_06_02_072811_create_article_images_table.php
+++ b/src/database/migrations/2019_06_02_072811_create_article_images_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateArticleImagesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('article_images', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedbigInteger('article_id');
+            $table->string('image_path');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('article_images');
+    }
+}

--- a/src/database/seeds/ArticleImagesTableSeeder.php
+++ b/src/database/seeds/ArticleImagesTableSeeder.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class ArticleImagesTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('article_images')->insert([
+            [
+                'article_id' => 1,
+                'image_path' => 'test/path1',
+            ],
+            [
+                'article_id' => 2,
+                'image_path' => 'test/path2',
+            ],
+            [
+                'article_id' => 3,
+                'image_path' => 'test/path3',
+            ],
+            [
+                'article_id' => 3,
+                'image_path' => 'test/path4',
+            ]
+        ]);
+    }
+}

--- a/src/database/seeds/ArticlesTableSeeder.php
+++ b/src/database/seeds/ArticlesTableSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class ArticlesTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('articles')->insert([
+            [
+            'title' => 'title1',
+            'body' => 'body1'
+            ],
+            [
+            'title' => 'title2',
+            'body' => 'body2'
+            ],
+            [
+            'title' => 'title3',
+            'body' => 'body3'
+            ],
+        ]);
+    }
+}

--- a/src/database/seeds/DatabaseSeeder.php
+++ b/src/database/seeds/DatabaseSeeder.php
@@ -12,5 +12,6 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
         // $this->call(UsersTableSeeder::class);
+        $this->call(ArticlesTableSeeder::class);
     }
 }

--- a/src/database/seeds/DatabaseSeeder.php
+++ b/src/database/seeds/DatabaseSeeder.php
@@ -13,5 +13,6 @@ class DatabaseSeeder extends Seeder
     {
         // $this->call(UsersTableSeeder::class);
         $this->call(ArticlesTableSeeder::class);
+        $this->call(ArticleImagesTableSeeder::class);
     }
 }

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -16,3 +16,7 @@ use Illuminate\Http\Request;
 Route::middleware('auth:api')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::group(['middleware' => ['api']], function() {
+    Route::resource('articles', 'Api\ArticlesController', ['except' => ['create', 'edit']]);
+});


### PR DESCRIPTION
# やったこと
- 記事(Article)のEntity, Controlle, Migration, Seeder追加
- 記事画像(ArticleImage)のEntity, Controller, Migration, Seeder追加
- 記事本文を100字に丸めるためのアクセサや、Markdownparse用のアクセサの追加